### PR TITLE
adding fix to allow ManyRelatedManager fields

### DIFF
--- a/table/utils.py
+++ b/table/utils.py
@@ -30,7 +30,10 @@ class Accessor(str):
                     obj = obj[int(level)]
                 else:
                     if callable(getattr(obj, level)):
-                        obj = getattr(obj, level)()
+                        try:
+                            obj = getattr(obj, level)()
+                        except KeyError:
+                            obj = getattr(obj, level)
                     else:
                         # for model field that has choice set
                         # use get_xxx_display to access


### PR DESCRIPTION
I was trying to use a manager object to get the count of things in a ManyToManyField in the table, but it was getting tripped up since the manager object is a callable.

I'm still fairly new to this library, so it's possible that I've just missed a better way to do this, but with this in place, I'm now able to add a field `fieldname_set.count` and have it work as I expected.