### PR TITLE
Fixed some django 1.10 & 2.0 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
+  - DJANGO_VERSION=1.10
 install:
   - pip install -q Django==$DJANGO_VERSION
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ install:
   - pip install -q Django==$DJANGO_VERSION
 script:
   - cd example
-  - python manage.py test table
+  - python -Wall manage.py test table
 

--- a/example/app/migrations/0002_auto_20150328_1648.py
+++ b/example/app/migrations/0002_auto_20150328_1648.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='person',
             name='organization',
-            field=models.ForeignKey(blank=True, to='app.Organization', null=True),
+            field=models.ForeignKey(blank=True, to='app.Organization', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/example/app/models.py
+++ b/example/app/models.py
@@ -7,5 +7,5 @@ class Organization(models.Model):
 
 class Person(models.Model):
     name = models.CharField(verbose_name="full name", max_length=100)
-    organization = models.ForeignKey(Organization, null=True, blank=True)
+    organization = models.ForeignKey(Organization, null=True, blank=True, on_delete=models.CASCADE)
     married = models.BooleanField(verbose_name="married", default=False)

--- a/example/app/tables.py
+++ b/example/app/tables.py
@@ -2,8 +2,13 @@
 # coding: utf-8
 
 from datetime import date
+import django
 
-from django.core.urlresolvers import reverse_lazy
+if django.VERSION >= (1, 10):
+    from django.urls import reverse_lazy
+else:
+    from django.core.urlresolvers import reverse_lazy
+
 from table.columns import Column
 from table.columns.calendarcolumn import CalendarColumn
 from table.columns.sequencecolumn import SequenceColumn

--- a/example/settings.py
+++ b/example/settings.py
@@ -83,14 +83,7 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'sq9c#o&amp;a0wyo%iv8gicf=3!eb=r9k9!lm!oz1150+=7g@-5i*^'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
-)
-
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -98,19 +91,33 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+]
 
 ROOT_URLCONF = 'urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'wsgi.application'
 
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    os.path.join(os.path.dirname(__file__), 'templates').replace('\\','/'),
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': [
+            os.path.join(os.path.dirname(__file__), 'templates').replace('\\','/'),
+        ],
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 INSTALLED_APPS = (
     'django.contrib.auth',

--- a/table/columns/linkcolumn.py
+++ b/table/columns/linkcolumn.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # coding: utf-8
-from django.core.urlresolvers import reverse
+import django
+
+if django.VERSION >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
+
 from django.utils.safestring import mark_safe
 from django.utils.html import escape
 from django.template import Template, Context

--- a/table/tests/test_views.py
+++ b/table/tests/test_views.py
@@ -2,9 +2,14 @@
 # coding: utf-8
 from __future__ import unicode_literals
 import json
+import django
 
 from django.test import Client, TestCase
-from django.core.urlresolvers import reverse
+
+if django.VERSION >= (1, 10):
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 
 from table import Table
 from table.columns import Column


### PR DESCRIPTION
As tells the [documentation](https://docs.djangoproject.com/en/1.10/ref/urlresolvers/) importing from `django.core.urlresolvers` is deprecated from django 1.10 and will be removed in django 2.0.
It complains when you run tests with `python -Wall`, but with this fix, it is OK.