### PR TITLE
Fixed datetime column default format

### DIFF
--- a/table/columns/datetimecolumn.py
+++ b/table/columns/datetimecolumn.py
@@ -8,7 +8,7 @@ from .base import Column
 
 class DatetimeColumn(Column):
 
-    DEFAULT_FORMAT = "%Y-%m-%d %H:%I:%S"
+    DEFAULT_FORMAT = "%Y-%m-%d %H:%M:%S"
 
     def __init__(self, field, header=None, format=None, **kwargs):
         self.format = format or DatetimeColumn.DEFAULT_FORMAT


### PR DESCRIPTION
Default format string in DatetimeColumn had one incorrect directive which caused hours to be displayed in the place of minutes.